### PR TITLE
add 'curl' to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     stringi,
     utils
 Suggests:
+    curl,
     roxygen2,
     testthat (>= 3.0.0)
 Config/rextendr/version: 0.3.1.9000


### PR DESCRIPTION
testthat::skip_if_offline() requires curl since v3.2.0